### PR TITLE
Fix potential overflow and some other minor renames / changes

### DIFF
--- a/src/backend/crypto/kmgr.c
+++ b/src/backend/crypto/kmgr.c
@@ -336,7 +336,7 @@ generate_crypto_key(int len)
 {
 	CryptoKey *newkey;
 
-	Assert(len <= KMGR_MAX_KEY_LEN);
+	Assert(len <= KMGR_MAX_KEY_LEN_BYTES);
 	newkey = (CryptoKey *) palloc0(sizeof(CryptoKey));
 
 	newkey->klen = len;

--- a/src/bin/pg_alterckey/pg_alterckey.c
+++ b/src/bin/pg_alterckey/pg_alterckey.c
@@ -63,7 +63,7 @@ static char old_cluster_key[KMGR_CLUSTER_KEY_LEN],
 static CryptoKey data_key;
 unsigned char in_key[MAX_WRAPPED_KEY_LENGTH], out_key[MAX_WRAPPED_KEY_LENGTH];
 int in_klen, out_klen;
-static char top_path[MAXPGPATH], pid_path[MAXPGPATH], live_path[MAXPGPATH],
+static char kmgr_dir[MAXPGPATH], pid_path[MAXPGPATH], live_path[MAXPGPATH],
 			new_path[MAXPGPATH], old_path[MAXPGPATH];
 
 static char *DataDir = NULL;
@@ -227,7 +227,7 @@ main(int argc, char *argv[])
 
 	umask(pg_mode_mask);
 
-	snprintf(top_path, sizeof(top_path), "%s/%s", DataDir, KMGR_DIR);
+	snprintf(kmgr_dir, sizeof(kmgr_dir), "%s/%s", DataDir, KMGR_DIR);
 	snprintf(pid_path, sizeof(pid_path), "%s/%s", DataDir, KMGR_DIR_PID);
 	snprintf(live_path, sizeof(live_path), "%s/%s", DataDir, LIVE_KMGR_DIR);
 	snprintf(new_path, sizeof(new_path), "%s/%s", DataDir, NEW_KMGR_DIR);
@@ -282,7 +282,7 @@ create_lockfile(void)
 	struct stat buffer;
 	char lock_pid_str[20];
 
-	if (stat(top_path, &buffer) != 0 || !S_ISDIR(buffer.st_mode))
+	if (stat(kmgr_dir, &buffer) != 0 || !S_ISDIR(buffer.st_mode))
 	{
 		pg_log_error("cluster file encryption directory \"%s\" is missing;  is it enabled?", KMGR_DIR_PID);
 		fprintf(stderr, _("Exiting with no changes made.\n"));

--- a/src/bin/pg_alterckey/pg_alterckey.c
+++ b/src/bin/pg_alterckey/pg_alterckey.c
@@ -298,7 +298,7 @@ create_lockfile(void)
 		/* read the PID */
 		if ((len = read(lock_fd, lock_pid_str, sizeof(lock_pid_str) - 1)) == 0)
 		{
-			pg_log_error("cannot read pid from lock file \"%s\": %m", KMGR_DIR_PID);
+			pg_log_error("could not read pid from lock file \"%s\": %m", KMGR_DIR_PID);
 			fprintf(stderr, _("Exiting with no changes made.\n"));
 			exit(1);
 		}
@@ -619,9 +619,9 @@ reencrypt_data_keys(void)
 			if (len != in_klen)
 			{
 				if (len < 0)
-					pg_log_error("could read file \"%s\": %m", src_path);
+					pg_log_error("could not read file \"%s\": %m", src_path);
 				else
-					pg_log_error("could read file \"%s\": read %d of %u",
+					pg_log_error("could not read file \"%s\": read %d of %u",
 							 src_path, len, in_klen);
 				bzero_keys_and_exit(RMDIR_EXIT);
 			}
@@ -650,7 +650,7 @@ reencrypt_data_keys(void)
 			len = write(dst_fd, out_key, out_klen);
 			if (len != out_klen)
 			{
-				pg_log_error("could not write fie \"%s\"", dst_path);
+				pg_log_error("could not write file \"%s\"", dst_path);
 				bzero_keys_and_exit(RMDIR_EXIT);
 			}
 

--- a/src/include/common/cipher.h
+++ b/src/include/common/cipher.h
@@ -34,13 +34,6 @@
 #define PG_AES192_KEY_LEN			(192 / 8)
 #define PG_AES256_KEY_LEN			(256 / 8)
 
-/*
- * The encrypted data is a series of blocks of size. Initialization
- * vector(IV) is the same size of cipher block.
- */
-#define PG_AES_BLOCK_SIZE			16
-#define PG_AES_IV_SIZE				(PG_AES_BLOCK_SIZE)
-
 #ifdef USE_OPENSSL
 typedef EVP_CIPHER_CTX PgCipherCtx;
 #else

--- a/src/include/common/kmgr_utils.h
+++ b/src/include/common/kmgr_utils.h
@@ -45,8 +45,8 @@
 #define ALLOC_KMGR_CLUSTER_KEY_LEN	(KMGR_CLUSTER_KEY_LEN * 2 + 10 + 2 + 1)
 
 /* Maximum length of key the key manager can store */
-#define KMGR_MAX_KEY_LEN			256
-#define KMGR_MAX_KEY_LEN_BYTES		KMGR_MAX_KEY_LEN / 8
+#define KMGR_MAX_KEY_LEN_BITS		256
+#define KMGR_MAX_KEY_LEN_BYTES		KMGR_MAX_KEY_LEN_BITS / 8
 
 
 /*


### PR DESCRIPTION
I've been trying to go through this patch. No major thoughts on the approach or code yet, but I did notice a few bugs and cosmetic items.

https://github.com/bmomjian/postgres/commit/818ee994d8a7c34778e99a22dd8793c4d05d28cd is an actual overflow bug. The CryptoKey struct max key length is 32-bytes but it's references the 256-bits constant in the assert.

The rest fix some typos, remove defined but unused constants, and give more explicit names (e.g. adding a _BITS suffix).